### PR TITLE
Added friendly_name variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,14 @@ Type: `string`
 
 Default: `"workspace-3"`
 
+### <a name="input_friendly_name"></a> [name](#input\_friendly_name)
+
+Description: The friendly name of the AVD Workspace. If this variable is not set, the [name](#input\_name) variable will be used as the friendly name.
+
+Type: `string`
+
+Default: `null`
+
 ### <a name="input_private_endpoints"></a> [private\_endpoints](#input\_private\_endpoints)
 
 Description: A map of private endpoints to create on the resource. The map key is deliberately arbitrary to avoid issues where map keys maybe unknown at plan time.

--- a/README.md
+++ b/README.md
@@ -107,6 +107,14 @@ Type: `bool`
 
 Default: `true`
 
+### <a name="input_friendly_name"></a> [friendly\_name](#input\_friendly\_name)
+
+Description: The friendly name of the AVD Workspace. It can be null or a string between 1 and 64 characters long.
+
+Type: `string`
+
+Default: `null`
+
 ### <a name="input_lock"></a> [lock](#input\_lock)
 
 Description:   Controls the Resource Lock configuration for this resource. The following properties can be specified:
@@ -132,14 +140,6 @@ Description: The name of the AVD Workspace.
 Type: `string`
 
 Default: `"workspace-3"`
-
-### <a name="input_friendly_name"></a> [name](#input\_friendly_name)
-
-Description: The friendly name of the AVD Workspace. If this variable is not set, the [name](#input\_name) variable will be used as the friendly name.
-
-Type: `string`
-
-Default: `null`
 
 ### <a name="input_private_endpoints"></a> [private\_endpoints](#input\_private\_endpoints)
 

--- a/locals.version.tf.json
+++ b/locals.version.tf.json
@@ -1,5 +1,5 @@
 {
   "locals": {
-    "module_version": "0.1.3"
+    "module_version": "0.1.4"
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,7 @@ resource "azurerm_virtual_desktop_workspace" "this" {
   name                          = var.name
   resource_group_name           = var.resource_group_name
   description                   = var.description
-  friendly_name                 = var.name
+  friendly_name                 = var.friendly_name != null ? var.friendly_name : var.name
   public_network_access_enabled = var.public_network_access_enabled
   tags                          = var.tags
 }

--- a/variables.tf
+++ b/variables.tf
@@ -101,6 +101,17 @@ variable "name" {
   }
 }
 
+variable "friendly_name" {
+  type        = string
+  default     = null
+  description = "The friendly name of the AVD Workspace. It can be null or a string between 1 and 64 characters long."
+
+  validation {
+    condition     = var.friendly_name == null || can(regex("^.{1,64}$", var.friendly_name))
+    error_message = "The friendly name must be null or a string between 1 and 64 characters long."
+  }
+}
+
 variable "private_endpoints" {
   type = map(object({
     name = optional(string, null)

--- a/variables.tf
+++ b/variables.tf
@@ -70,6 +70,17 @@ If it is set to false, then no telemetry will be collected.
 DESCRIPTION
 }
 
+variable "friendly_name" {
+  type        = string
+  default     = null
+  description = "The friendly name of the AVD Workspace. It can be null or a string between 1 and 64 characters long."
+
+  validation {
+    condition     = var.friendly_name == null || can(regex("^.{1,64}$", var.friendly_name))
+    error_message = "The friendly name must be null or a string between 1 and 64 characters long."
+  }
+}
+
 # tflint-ignore: terraform_unused_declarations
 variable "lock" {
   type = object({
@@ -98,17 +109,6 @@ variable "name" {
   validation {
     condition     = can(regex("^[a-z0-9-]{3,24}$", var.name))
     error_message = "The name must be between 3 and 24 characters long and can only contain lowercase letters, numbers and dashes."
-  }
-}
-
-variable "friendly_name" {
-  type        = string
-  default     = null
-  description = "The friendly name of the AVD Workspace. It can be null or a string between 1 and 64 characters long."
-
-  validation {
-    condition     = var.friendly_name == null || can(regex("^.{1,64}$", var.friendly_name))
-    error_message = "The friendly name must be null or a string between 1 and 64 characters long."
   }
 }
 


### PR DESCRIPTION
## Description

I added the `friendly_name` variable to this module. The variable already exists from the `azurerm_virtual_desktop_workspace` resource and allows you to specify a "friendly" name for the workspace that will be displayed to end users. Since the `description` variable is already implemented, I think it makes sense to do the same for `friendly_name`.

`friendly_name` has a default value of `null`. This enables downward compatibility. In this case, `name` is used as `friendly_name` - so the behavior is not changed and a `terraform apply` does not perform an update.

~ Thomas

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `locals.version.tf.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [x] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [x] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `locals.version.tf.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `locals.version.tf.json`.
  - [x] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
