### PR TITLE
fix: added Azapi as provider

### DIFF
--- a/terraform.tf
+++ b/terraform.tf
@@ -1,6 +1,10 @@
 terraform {
   required_version = ">= 1.9, < 2.0"
   required_providers {
+    azapi = {
+      source  = "azure/azapi"
+      version = ">= 1.0.0"
+    }
     azurerm = {
       source  = "hashicorp/azurerm"
       version = ">= 3.71, < 5.0.0"


### PR DESCRIPTION
## Description
Added the azapi provider to terraform.tf to resolve terraform init failures. This change ensures that all required providers are properly declared and terraform initialization can complete successfully.

## Type of Change
- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [x] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist
- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all [[pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks)](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks